### PR TITLE
Replace redhat connectivity subpackage with openela one - el8.8

### DIFF
--- a/SOURCES/20-connectivity-openela.conf
+++ b/SOURCES/20-connectivity-openela.conf
@@ -5,6 +5,6 @@
 # strict. Check "/proc/sys/net/ipv4/conf/*/rp_filter".
 [connectivity]
 enabled=true
-uri=http://static.redhat.com/test/rhel-networkmanager.txt
+uri=http://example.sample.org/connectivity.txt
 response=OK
 interval=300

--- a/SPECS/NetworkManager.spec
+++ b/SPECS/NetworkManager.spec
@@ -72,9 +72,9 @@
 %bcond_with connectivity_fedora
 %endif
 %if 0%{?rhel} && 0%{?rhel} >= 8
-%bcond_without connectivity_redhat
+%bcond_without connectivity_openela
 %else
-%bcond_with connectivity_redhat
+%bcond_with connectivity_openela
 %endif
 %if 0%{?fedora} >= 29 || 0%{?rhel} >= 8
 %bcond_without crypto_gnutls
@@ -174,7 +174,7 @@ Name: NetworkManager
 Summary: Network connection manager and user applications
 Epoch: %{epoch_version}
 Version: %{rpm_version}
-Release: %{release_version}%{?snap}%{?dist}
+Release: %{release_version}%{?snap}.0.1%{?dist}
 Group: System Environment/Base
 License: GPLv2+ and LGPLv2+
 URL: https://networkmanager.dev/
@@ -183,7 +183,7 @@ Source: https://download.gnome.org/sources/NetworkManager/%{real_version_major}/
 Source1: NetworkManager.conf
 Source2: 00-server.conf
 Source4: 20-connectivity-fedora.conf
-Source5: 20-connectivity-redhat.conf
+Source5: 20-connectivity-openela.conf
 Source6: 70-nm-connectivity.conf
 Source7: readme-ifcfg-rh.txt
 
@@ -503,16 +503,16 @@ via Fedora infrastructure.
 %endif
 
 
-%if %{with connectivity_redhat}
-%package config-connectivity-redhat
-Summary: NetworkManager config file for connectivity checking via Red Hat servers
+%if %{with connectivity_openela}
+%package config-connectivity-openela
+Summary: NetworkManager config file for connectivity checking via OpenELA servers
 Group: System Environment/Base
 BuildArch: noarch
 Provides: NetworkManager-config-connectivity = %{epoch}:%{version}-%{release}
 
-%description config-connectivity-redhat
+%description config-connectivity-openela
 This adds a NetworkManager configuration file to enable connectivity checking
-via Red Hat infrastructure.
+via OpenELA infrastructure.
 %endif
 
 
@@ -892,7 +892,7 @@ cp %{SOURCE2} %{buildroot}%{nmlibdir}/conf.d/
 cp %{SOURCE4} %{buildroot}%{nmlibdir}/conf.d/
 %endif
 
-%if %{with connectivity_redhat}
+%if %{with connectivity_openela}
 cp %{SOURCE5} %{buildroot}%{nmlibdir}/conf.d/
 mkdir -p %{buildroot}%{_sysctldir}
 cp %{SOURCE6} %{buildroot}%{_sysctldir}
@@ -1177,11 +1177,11 @@ fi
 %endif
 
 
-%if %{with connectivity_redhat}
-%files config-connectivity-redhat
+%if %{with connectivity_openela}
+%files config-connectivity-openela
 %dir %{nmlibdir}
 %dir %{nmlibdir}/conf.d
-%{nmlibdir}/conf.d/20-connectivity-redhat.conf
+%{nmlibdir}/conf.d/20-connectivity-openela.conf
 %{_sysctldir}/70-nm-connectivity.conf
 %endif
 
@@ -1234,6 +1234,9 @@ fi
 
 
 %changelog
+* Wed Nov 01 2023 Alex Burmashev <alexander.burmashev@oracle.com> - 1:1.40.16-4.0.1
+- Replace connectivity-redhat sub-package with connectivity-openela
+
 * Thu Jun 29 2023 Gris Ge <fge@redhat.com> - 1:1.40.16-4
 - unblock autoconnect upon reapply (rh #2217899)
 


### PR DESCRIPTION
URL used for network connectivity check is specifically set to a dummy non-functional URL.